### PR TITLE
ensure directory for the output file

### DIFF
--- a/source-record.c
+++ b/source-record.c
@@ -374,6 +374,27 @@ static void *start_replay_thread(void *data)
 	return NULL;
 }
 
+static void ensure_directory(char *path)
+{
+#ifdef _WIN32
+	char *backslash = strrchr(path, '\\');
+	if (backslash)
+		*backslash = '/';
+#endif
+
+	char *slash = strrchr(path, '/');
+	if (slash) {
+		*slash = 0;
+		os_mkdirs(path);
+		*slash = '/';
+	}
+
+#ifdef _WIN32
+	if (backslash)
+		*backslash = '\\';
+#endif
+}
+
 static void start_file_output(struct source_record_filter_context *filter,
 			      obs_data_t *settings)
 {
@@ -385,6 +406,7 @@ static void start_file_output(struct source_record_filter_context *filter,
 	snprintf(path, 512, "%s/%s", obs_data_get_string(settings, "path"),
 		 filename);
 	bfree(filename);
+	ensure_directory(path);
 	obs_data_set_string(s, "path", path);
 	if (!filter->fileOutput) {
 		filter->fileOutput = obs_output_create(


### PR DESCRIPTION
This PR allows user to specify separated directories base on the date as suggested in #46.

The implementation is inspired by obs-ffmpeg-mux in obs-studio.
https://github.com/obsproject/obs-studio/blob/525c535459811e17ab13eb3fda2d9e9541f0d8ae/plugins/obs-ffmpeg/obs-ffmpeg-mux.c#L923-L934
However, a small improvement is added so that the user can specify file names including backslash (`\`) in non-Windows systems.

For example, if a user input `%CCYY-%MM-%DD/%hh-%mm-%ss` to `filename_formatting` property, the user can achieve to save files to the directory `%CCYY-%MM-%DD`, which will be expanded to current date.

A new function `ensure_directory` is added. The function behaves as below.
- Temporarily replace the last directory-separator with `\0`.
- Calls `os_mkdirs` to ensure the existence of the directory.
- Finally, reverts the replaced character.

In Windows, in addition to the steps above, the last `\` is replaced before the steps above, and reverted after the steps so that `\` is also works as the directory separator.

During above steps, however the file name is intermediately modified, the file name is completely reverted so that the other behaviors should not be affected.