### PR TITLE
fix memory leak

### DIFF
--- a/source-record.c
+++ b/source-record.c
@@ -379,10 +379,12 @@ static void start_file_output(struct source_record_filter_context *filter,
 {
 	obs_data_t *s = obs_data_create();
 	char path[512];
+	char *filename = os_generate_formatted_filename(
+		obs_data_get_string(settings, "rec_format"), true,
+		obs_data_get_string(settings, "filename_formatting"));
 	snprintf(path, 512, "%s/%s", obs_data_get_string(settings, "path"),
-		 os_generate_formatted_filename(
-			 obs_data_get_string(settings, "rec_format"), true,
-			 obs_data_get_string(settings, "filename_formatting")));
+		 filename);
+	bfree(filename);
 	obs_data_set_string(s, "path", path);
 	if (!filter->fileOutput) {
 		filter->fileOutput = obs_output_create(


### PR DESCRIPTION
### Description

Release file name string returned by `os_generate_formatted_filename`.

### Motivation and Context

Prior to this change, OBS reported memory leaks.

### How Has This Been Tested?

Tested on Fedora 34.

Scene collection setup:
1. Add Source Record filter to a source
2. Set `Record Mode` to `Recording`

To check the memory leaks,
1. Start OBS
2. Start recording, wait 2 or 3 seconds, stop recording.
3. Exit OBS
4. Check memory leaks reported in the log.