### PR TITLE
Add source_record_save_replay_hotkey

### DIFF
--- a/source-record.c
+++ b/source-record.c
@@ -47,6 +47,7 @@ struct source_record_filter_context {
 	obs_hotkey_pair_id pauseHotkeys;
 	obs_hotkey_id splitHotkey;
 	obs_hotkey_id chapterHotkey;
+	obs_hotkey_id saveReplayHotkey;
 	int audio_track;
 	obs_weak_source_t *audio_source;
 	bool closing;
@@ -1112,6 +1113,7 @@ static void *source_record_filter_create(obs_data_t *settings, obs_source_t *sou
 	context->pauseHotkeys = OBS_INVALID_HOTKEY_PAIR_ID;
 	context->splitHotkey = OBS_INVALID_HOTKEY_ID;
 	context->chapterHotkey = OBS_INVALID_HOTKEY_ID;
+	context->saveReplayHotkey = OBS_INVALID_HOTKEY_ID;
 	source_record_filter_update(context, settings);
 	obs_frontend_add_event_callback(frontend_event, context);
 	return context;
@@ -1204,6 +1206,9 @@ static void source_record_filter_destroy(void *data)
 
 	if (context->chapterHotkey != OBS_INVALID_HOTKEY_ID)
 		obs_hotkey_unregister(context->chapterHotkey);
+
+	if (context->saveReplayHotkey != OBS_INVALID_HOTKEY_ID)
+		obs_hotkey_unregister(context->saveReplayHotkey);
 
 	context->source = NULL;
 	source_record_delayed_destroy(context);
@@ -1298,6 +1303,28 @@ static void source_record_chapter_hotkey(void *data, obs_hotkey_id id, obs_hotke
 	calldata_free(&cd);
 }
 
+static void source_record_save_replay_hotkey(void *data, obs_hotkey_id id, obs_hotkey_t *hotkey, bool pressed)
+{
+    UNUSED_PARAMETER(id);
+    UNUSED_PARAMETER(hotkey);
+
+    if (!pressed)
+        return;
+
+    struct source_record_filter_context *context = data;
+    if (!context->replayOutput)
+        return;
+
+    proc_handler_t *ph = obs_output_get_proc_handler(context->replayOutput);
+    if (!ph)
+        return;
+
+    struct calldata cd;
+    calldata_init(&cd);
+    proc_handler_call(ph, "save", &cd);
+    calldata_free(&cd);
+}
+
 static void source_record_filter_tick(void *data, float seconds)
 {
 	UNUSED_PARAMETER(seconds);
@@ -1335,6 +1362,11 @@ static void source_record_filter_tick(void *data, float seconds)
 		context->chapterHotkey = obs_hotkey_register_source(parent, "source_record.AddChapterMarker",
 								    obs_frontend_get_locale_string("Basic.Main.AddChapterMarker"),
 								    source_record_chapter_hotkey, context);
+
+	if (context->saveReplayHotkey == OBS_INVALID_HOTKEY_ID)
+		context->saveReplayHotkey = obs_hotkey_register_source(
+			parent, "source_record.SaveReplay", obs_frontend_get_locale_string("Basic.Main.SaveReplayBuffer"),
+			source_record_save_replay_hotkey, context);
 
 	uint32_t width = obs_source_get_width(parent);
 	width += (width & 1);


### PR DESCRIPTION
This is for use with [obs-wayland-hotkeys](https://github.com/leia-uwu/obs-wayland-hotkeys) so it is listed as a global hotkey.

Example:
com.obsproject.Studio:source_record.SaveReplay.CAMLINK_4K -> Basic.Main.SaveReplayBuffer (CAMLINK 4K)

I can then use this to create global hotkeys on Wayland.