### PR TITLE
Fix crash on source resize while Replay Buffer is active (#166)

### DIFF
--- a/source-record.c
+++ b/source-record.c
@@ -688,8 +688,13 @@ static void set_encoder_defaults(obs_data_t *settings)
 static void update_encoder(struct source_record_filter_context *filter, obs_data_t *settings)
 {
 	const char *enc_id = get_encoder_id(settings);
-	if (!filter->encoder || strcmp(obs_encoder_get_id(filter->encoder), enc_id) != 0) {
+	const bool need_new_encoder = !filter->encoder || strcmp(obs_encoder_get_id(filter->encoder), enc_id) != 0;
+	if (need_new_encoder && filter->encoder && obs_encoder_active(filter->encoder)) {
+		/* Fix: an active encoder is never released here. Releasing an
+		 * in-use encoder caused crashes; it is swapped once idle. */
+	} else if (need_new_encoder) {
 		obs_encoder_release(filter->encoder);
+		filter->encoder = NULL;
 		set_encoder_defaults(settings);
 		filter->encoder = obs_video_encoder_create(enc_id, obs_source_get_name(filter->source), settings, NULL);
 
@@ -719,6 +724,9 @@ static void update_encoder(struct source_record_filter_context *filter, obs_data
 		if (filter->replayOutput && obs_output_get_video_encoder(filter->replayOutput) != filter->encoder)
 			obs_output_set_video_encoder(filter->replayOutput, filter->encoder);
 	} else if (!obs_encoder_active(filter->encoder)) {
+		/* Fix: re-point the encoder at the current video_output in case
+		 * the view was recreated after a parent size change. */
+		obs_encoder_set_video(filter->encoder, filter->video_output);
 		obs_encoder_update(filter->encoder, settings);
 	}
 	const int audio_track = obs_data_get_bool(settings, "different_audio") ? (int)obs_data_get_int(settings, "audio_track") : 0;
@@ -1349,7 +1357,13 @@ static void source_record_filter_tick(void *data, float seconds)
 	width += (width & 1);
 	uint32_t height = obs_source_get_height(parent);
 	height += (height & 1);
-	if (width && height && (!context->video_output || context->width != width || context->height != height)) {
+	/* Fix: never destroy the video_output while an encoder is still feeding
+	 * from it. A size change on the parent (window capture / PipeWire on
+	 * focus change) used to call obs_view_remove() immediately, freeing the
+	 * video_output under a running encoder + replay buffer -> crash. */
+	const bool size_changed = width && height && (context->width != width || context->height != height);
+
+	if (width && height && !context->video_output) {
 		struct obs_video_info ovi = {0};
 		obs_get_video_info(&ovi);
 
@@ -1361,17 +1375,35 @@ static void source_record_filter_tick(void *data, float seconds)
 		if (!context->view)
 			context->view = obs_view_create();
 
-		const bool restart = !!context->video_output;
-		if (restart)
-			obs_view_remove(context->view);
-
 		context->video_output = obs_view_add2(context->view, &ovi);
 		if (context->video_output) {
 			context->width = width;
 			context->height = height;
-			if (restart)
-				context->restart = true;
 		}
+	} else if (size_changed && context->video_output) {
+		if (context->output_active) {
+			/* defer: let the restart branch stop the outputs first */
+			context->restart = true;
+		} else if (!context->encoder || !obs_encoder_active(context->encoder)) {
+			/* outputs are down and the encoder is idle: safe to swap */
+			struct obs_video_info ovi = {0};
+			obs_get_video_info(&ovi);
+
+			ovi.base_width = width;
+			ovi.base_height = height;
+			ovi.output_width = width;
+			ovi.output_height = height;
+
+			obs_view_remove(context->view);
+			context->video_output = obs_view_add2(context->view, &ovi);
+			if (context->video_output) {
+				context->width = width;
+				context->height = height;
+				if (context->encoder)
+					obs_encoder_set_video(context->encoder, context->video_output);
+			}
+		}
+		/* else: encoder still winding down, retry on the next tick */
 	}
 
 	if (context->restart && context->output_active) {
@@ -1403,6 +1435,10 @@ static void source_record_filter_tick(void *data, float seconds)
 		   (context->replayBuffer || context->record || context->stream)) {
 		if (context->starting_file_output || context->starting_stream_output || context->starting_replay_output ||
 		    !context->video_output || !width || !height)
+			return;
+		/* Fix: don't start new outputs (and reuse / re-point the encoder)
+		 * while a previous output is still draining it -> use-after-free. */
+		if (context->encoder && obs_encoder_active(context->encoder))
 			return;
 		obs_data_t *s = obs_source_get_settings(context->source);
 		update_encoder(context, s);


### PR DESCRIPTION
Hi exeldro,

I ran into the crash described in #166 and tracked down the cause.
This PR fixes it.

## The problem

When a source's resolution changes while a Source Record filter has
the Replay Buffer enabled (for example, tabbing in/out of a window
capture), OBS crashes.

`source_record_filter_tick()` recreated the `obs_view` / `video_output`
by calling `obs_view_remove()` immediately on a size change — while the
encoder was still feeding from the old `video_output` and the replay
buffer output was still running. The encoder kept pulling frames from a
freed `video_output`, causing a use-after-free crash.

Three related issues:

1. **video_output destroyed while in use** — `obs_view_remove()` ran
   synchronously on a size change, even with outputs/encoder still active.
2. **encoder released while active** — `update_encoder()` called
   `obs_encoder_release()` without checking `obs_encoder_active()` first
   (`release_encoders()` already does this check, so it was inconsistent).
3. **race on async restart** — new outputs could start (reusing the
   encoder) while a previous output was still being force-stopped.

## The fix

- On a size change with active outputs, only set `restart = true` and
  defer recreation. `video_output` is recreated only once outputs are
  down and the encoder is idle.
- `update_encoder()` no longer releases an active encoder, and re-points
  the encoder to the current `video_output` when reusing an idle one.
- The output-start path waits until any previous encoder has fully wound
  down before starting new outputs.

44 lines changed; no behavior change for the normal start/stop path.

## Testing

Tested on Windows with OBS 32.1.2. Ran 8 simultaneous Source Record
filters with Replay Buffer enabled for ~37 minutes — 100+ replay saves,
repeated scene switches and source resizes. No crashes, clean shutdown.
The same scenario reliably crashed before the patch.

Thanks for the plugin!